### PR TITLE
Avoid polluting the main:: namespace

### DIFF
--- a/lib/Locale/SubCountry.pm
+++ b/lib/Locale/SubCountry.pm
@@ -286,12 +286,13 @@ it under the same terms as Perl itself.
 =cut
 
 #-------------------------------------------------------------------------------
+package Locale::SubCountry;
 
 use strict;
 use warnings;
 use locale;
 use Exporter;
-use JSON;
+use JSON();
 use Locale::SubCountry::Codes;
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Imports from Exporter and JSON were ending up in namespace main:: - this conflicts with code running with Dancer, for example.

Add package declaration before loading modules with `use`